### PR TITLE
Add RivosTest extension for local tests.

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -8,6 +8,10 @@ pub mod debug_console;
 /// Host interfaces for reset extension.
 pub mod reset;
 
+/// Host interfaces for local rivos testing.
+#[cfg(all(target_arch = "riscv64", target_os = "none"))]
+pub mod rivos_test;
+
 /// Host interfaces for hart state management.
 pub mod state;
 

--- a/src/api/rivos_test.rs
+++ b/src/api/rivos_test.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{ecall_send, rivos_test, Result, RivosTestFunction, SbiMessage};
+
+/// Copies `len` bytes from `from` to `to`.
+///
+/// # Safety
+///
+/// - `to` must be writable for `len` bytes.
+/// - `src` must be readable for `len` bytes.
+/// - the ranges starting at `to` and `src` for `len` bytes must not overlap.
+/// - nothing mutates the memory of the `to` and `from` ranges while this function is called.
+pub unsafe fn test_memcpy(to: *mut u8, from: *const u8, len: u64) -> Result<()> {
+    let msg = SbiMessage::RivosTest(RivosTestFunction::MemCopy(rivos_test::MemCopyArgs {
+        to: to as u64,
+        from: from as u64,
+        len,
+    }));
+    ecall_send(&msg)?;
+    Ok(())
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -16,6 +16,7 @@ pub const EXT_NACL: u64 = 0x4E41434C; // NACL
 pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
 pub const EXT_TEE_INTERRUPT: u64 = 0x54454549; // TEEI
 pub const EXT_TEE_GUEST: u64 = 0x54454547; // TEEG
+pub const EXT_RIVOS_TEST: u64 = 0x09FFFFFF; // (Vendor-specific) Test.
 
 pub const SBI_SUCCESS: i64 = 0;
 pub const SBI_ERR_INVALID_ADDRESS: i64 = -5;

--- a/src/rivos_test.rs
+++ b/src/rivos_test.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::function::*;
+
+/// Functions defined for the Rivos test extension
+#[derive(Clone, Copy, Debug)]
+pub enum RivosTestFunction {
+    /// Returns the implemented version of the SBI standard.
+    MemCopy(MemCopyArgs),
+}
+
+impl RivosTestFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use RivosTestFunction::*;
+
+        match args[6] {
+            0 => Ok(MemCopy(MemCopyArgs {
+                to: args[0],
+                from: args[1],
+                len: args[2],
+            })),
+            _ => Err(Error::NotSupported),
+        }
+    }
+}
+
+impl SbiFunction for RivosTestFunction {
+    fn a6(&self) -> u64 {
+        use RivosTestFunction::*;
+        match self {
+            MemCopy(_) => 0,
+        }
+    }
+
+    fn a0(&self) -> u64 {
+        use RivosTestFunction::*;
+        match self {
+            MemCopy(args) => args.to,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        use RivosTestFunction::*;
+        match self {
+            MemCopy(args) => args.from,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        use RivosTestFunction::*;
+        match self {
+            MemCopy(args) => args.len,
+        }
+    }
+}
+
+/// Arguments to the memcpy test function
+#[derive(Clone, Copy, Debug)]
+pub struct MemCopyArgs {
+    /// Destination Address.
+    pub to: u64,
+    /// Source Address.
+    pub from: u64,
+    /// Length in bytes of the copy.
+    pub len: u64,
+}

--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -27,6 +27,9 @@ pub use nacl::*;
 // The reset SBI extension
 mod reset;
 pub use reset::*;
+// The rivos-specific test extension
+mod rivos_test;
+pub use rivos_test::*;
 // The State SBI extension
 mod state;
 pub use state::*;
@@ -130,6 +133,8 @@ pub enum SbiMessage {
     Attestation(AttestationFunction),
     /// The extension for getting performance counter state.
     Pmu(PmuFunction),
+    /// Tests run by Tellus
+    RivosTest(RivosTestFunction),
 }
 
 impl SbiMessage {
@@ -151,6 +156,7 @@ impl SbiMessage {
             EXT_TEE_GUEST => TeeGuestFunction::from_regs(args).map(SbiMessage::TeeGuest),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
             EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
+            EXT_RIVOS_TEST => RivosTestFunction::from_regs(args).map(SbiMessage::RivosTest),
             _ => Err(Error::NotSupported),
         }
     }
@@ -170,6 +176,7 @@ impl SbiMessage {
             TeeGuest(_) => EXT_TEE_GUEST,
             Attestation(_) => EXT_ATTESTATION,
             Pmu(_) => EXT_PMU,
+            RivosTest(_) => EXT_RIVOS_TEST,
         }
     }
 
@@ -190,6 +197,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a6(),
             Attestation(f) => f.a6(),
             Pmu(f) => f.a6(),
+            RivosTest(f) => f.a6(),
         }
     }
 
@@ -208,6 +216,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a5(),
             Attestation(f) => f.a5(),
             Pmu(f) => f.a5(),
+            RivosTest(f) => f.a5(),
         }
     }
 
@@ -226,6 +235,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a4(),
             Attestation(f) => f.a4(),
             Pmu(f) => f.a4(),
+            RivosTest(f) => f.a4(),
         }
     }
 
@@ -244,6 +254,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a3(),
             Attestation(f) => f.a3(),
             Pmu(f) => f.a3(),
+            RivosTest(f) => f.a3(),
         }
     }
 
@@ -262,6 +273,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a2(),
             Attestation(f) => f.a2(),
             Pmu(f) => f.a2(),
+            RivosTest(f) => f.a2(),
         }
     }
 
@@ -280,6 +292,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a1(),
             Attestation(f) => f.a1(),
             Pmu(f) => f.a1(),
+            RivosTest(f) => f.a1(),
         }
     }
 
@@ -298,6 +311,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a0(),
             Attestation(f) => f.a0(),
             Pmu(f) => f.a0(),
+            RivosTest(f) => f.a0(),
         }
     }
 


### PR DESCRIPTION
Original patch by Dylan Reid. This adds a "RivosTest" extension for  testing of temporary salus feature.

I think this opens the question of what to do with non-standard and testing extensions.