### PR TITLE
DRAFT: Add data-agnostic Vendor extension area support

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -17,5 +17,9 @@ pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
 pub const EXT_TEE_INTERRUPT: u64 = 0x54454549; // TEEI
 pub const EXT_TEE_GUEST: u64 = 0x54454547; // TEEG
 
+pub const EXT_VENDOR_RANGE_START: u64 = 0x09000000;
+pub const EXT_VENDOR_RANGE_END: u64 = 0x09FFFFFF;
+
+
 pub const SBI_SUCCESS: i64 = 0;
 pub const SBI_ERR_INVALID_ADDRESS: i64 = -5;

--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -43,6 +43,10 @@ pub use tee_guest::*;
 mod pmu;
 pub use pmu::*;
 
+// The Vendor SBI extension
+mod vendor;
+pub use vendor::*;
+
 /// Interfaces for invoking SBI functionality.
 pub mod api;
 
@@ -130,6 +134,8 @@ pub enum SbiMessage {
     Attestation(AttestationFunction),
     /// The extension for getting performance counter state.
     Pmu(PmuFunction),
+    /// The extension for making vendor-specific calls.
+    Vendor(VendorFunction),
 }
 
 impl SbiMessage {
@@ -151,6 +157,7 @@ impl SbiMessage {
             EXT_TEE_GUEST => TeeGuestFunction::from_regs(args).map(SbiMessage::TeeGuest),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
             EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
+            EXT_VENDOR_RANGE_START..=EXT_VENDOR_RANGE_END => VendorFunction::from_regs(args).map(SbiMessage::Vendor),
             _ => Err(Error::NotSupported),
         }
     }
@@ -170,6 +177,7 @@ impl SbiMessage {
             TeeGuest(_) => EXT_TEE_GUEST,
             Attestation(_) => EXT_ATTESTATION,
             Pmu(_) => EXT_PMU,
+            Vendor(_) => EXT_VENDOR_RANGE_END,
         }
     }
 
@@ -190,6 +198,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a6(),
             Attestation(f) => f.a6(),
             Pmu(f) => f.a6(),
+            Vendor(f) => f.a6(),
         }
     }
 
@@ -208,6 +217,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a5(),
             Attestation(f) => f.a5(),
             Pmu(f) => f.a5(),
+            Vendor(f) => f.a5(),
         }
     }
 
@@ -226,6 +236,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a4(),
             Attestation(f) => f.a4(),
             Pmu(f) => f.a4(),
+            Vendor(f) => f.a4(),
         }
     }
 
@@ -244,6 +255,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a3(),
             Attestation(f) => f.a3(),
             Pmu(f) => f.a3(),
+            Vendor(f) => f.a3(),
         }
     }
 
@@ -262,6 +274,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a2(),
             Attestation(f) => f.a2(),
             Pmu(f) => f.a2(),
+            Vendor(f) => f.a2(),
         }
     }
 
@@ -280,6 +293,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a1(),
             Attestation(f) => f.a1(),
             Pmu(f) => f.a1(),
+            Vendor(f) => f.a1(),
         }
     }
 
@@ -298,6 +312,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a0(),
             Attestation(f) => f.a0(),
             Pmu(f) => f.a0(),
+            Vendor(f) => f.a0(),
         }
     }
 

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -1,0 +1,229 @@
+// Copyright (c) 2023 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::function::*;
+
+/// Functions for the Reset extension
+#[derive(Copy, Clone, Debug)]
+pub enum VendorFunction {
+    /// Sends a Vendor-specific message
+    Vendor {
+        eid: u32,
+        fid: u32,
+        arg0: u64,
+        arg1: u64,
+        arg2: u64,
+        arg3: u64,
+        arg4: u64,
+        arg5: u64,
+    },
+}
+
+impl VendorFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use VendorFunction::*;
+
+        Ok(match args[8] {
+            0 => Vendor {
+                eid: 0,
+                fid: 0,
+                arg0: (args[0]),
+                arg1: (args[1]),
+                arg2: (args[2]),
+                arg3: (args[3]),
+                arg4: (args[4]),
+                arg5: (args[5]),
+            },
+            _ => return Err(Error::NotSupported),
+        })
+    }
+
+    pub fn call0(eid: u32, fid: u32, arg0: u64) -> Self {
+        VendorFunction::Vendor {
+            eid: (eid),
+            fid: (fid),
+            arg0: (arg0),
+            arg1: (0),
+            arg2: (0),
+            arg3: (0),
+            arg4: (0),
+            arg5: (0),
+        }
+    }
+
+    pub fn call1(eid: u32, fid: u32, arg0: u64, arg1: u64) -> Self {
+        VendorFunction::Vendor {
+            eid: (eid),
+            fid: (fid),
+            arg0: (arg0),
+            arg1: (arg1),
+            arg2: (0),
+            arg3: (0),
+            arg4: (0),
+            arg5: (0),
+        }
+    }
+
+    pub fn call2(eid: u32, fid: u32, arg0: u64, arg1: u64, arg2: u64) -> Self {
+        VendorFunction::Vendor {
+            eid: (eid),
+            fid: (fid),
+            arg0: (arg0),
+            arg1: (arg1),
+            arg2: (arg2),
+            arg3: (0),
+            arg4: (0),
+            arg5: (0),
+        }
+    }
+
+    pub fn call3(eid: u32, fid: u32, arg0: u64, arg1: u64, arg2: u64, arg3: u64) -> Self {
+        VendorFunction::Vendor {
+            eid: (eid),
+            fid: (fid),
+            arg0: (arg0),
+            arg1: (arg1),
+            arg2: (arg2),
+            arg3: (arg3),
+            arg4: (0),
+            arg5: (0),
+        }
+    }
+
+    pub fn call4(
+        eid: u32,
+        fid: u32,
+        arg0: u64,
+        arg1: u64,
+        arg2: u64,
+        arg3: u64,
+        arg4: u64,
+    ) -> Self {
+        VendorFunction::Vendor {
+            eid: (eid),
+            fid: (fid),
+            arg0: (arg0),
+            arg1: (arg1),
+            arg2: (arg2),
+            arg3: (arg3),
+            arg4: (arg4),
+            arg5: (0),
+        }
+    }
+
+    pub fn call5(
+        eid: u32,
+        fid: u32,
+        arg0: u64,
+        arg1: u64,
+        arg2: u64,
+        arg3: u64,
+        arg4: u64,
+        arg5: u64,
+    ) -> Self {
+        VendorFunction::Vendor {
+            eid: (eid),
+            fid: (fid),
+            arg0: (arg0),
+            arg1: (arg1),
+            arg2: (arg2),
+            arg3: (arg3),
+            arg4: (arg4),
+            arg5: (arg5),
+        }
+    }
+}
+
+impl SbiFunction for VendorFunction {
+    fn a0(&self) -> u64 {
+        match self {
+            VendorFunction::Vendor {
+                eid: _,
+                fid: _,
+                arg0,
+                arg1: _,
+                arg2: _,
+                arg3: _,
+                arg4: _,
+                arg5: _,
+            } => *arg0 as u64,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        match self {
+            VendorFunction::Vendor {
+                eid: _,
+                fid: _,
+                arg0: _,
+                arg1,
+                arg2: _,
+                arg3: _,
+                arg4: _,
+                arg5: _,
+            } => *arg1 as u64,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        match self {
+            VendorFunction::Vendor {
+                eid: _,
+                fid: _,
+                arg0: _,
+                arg1: _,
+                arg2,
+                arg3: _,
+                arg4: _,
+                arg5: _,
+            } => *arg2 as u64,
+        }
+    }
+
+    fn a3(&self) -> u64 {
+        match self {
+            VendorFunction::Vendor {
+                eid: _,
+                fid: _,
+                arg0: _,
+                arg1: _,
+                arg2: _,
+                arg3,
+                arg4: _,
+                arg5: _,
+            } => *arg3 as u64,
+        }
+    }
+    fn a4(&self) -> u64 {
+        match self {
+            VendorFunction::Vendor {
+                eid: _,
+                fid: _,
+                arg0: _,
+                arg1: _,
+                arg2: _,
+                arg3: _,
+                arg4,
+                arg5: _,
+            } => *arg4 as u64,
+        }
+    }
+
+    fn a5(&self) -> u64 {
+        match self {
+            VendorFunction::Vendor {
+                eid: _,
+                fid: _,
+                arg0: _,
+                arg1: _,
+                arg2: _,
+                arg3: _,
+                arg4: _,
+                arg5,
+            } => *arg5 as u64,
+        }
+    }
+}


### PR DESCRIPTION
This change introduces the VendorFunction, with the intent that users of this API will:

- explicitly provide the EID and FID that they wish to use
- the EID will be in the Vendor SBI extension range
- they know a priori the function signature, and use the appropriate harness

TODO:
- API front-end
- Cascade of 'known' Vendor types before using generic handler?
- Tests