### PR TITLE
Implement Vendor extensions.

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -31,3 +31,6 @@ pub mod base;
 
 /// Host interfaces for attestation.
 pub mod attestation;
+
+/// Salus vendor extensions.
+pub mod salus;

--- a/src/api/salus.rs
+++ b/src/api/salus.rs
@@ -1,0 +1,25 @@
+// Copyright (c) 2023 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::salus::*;
+use crate::{ecall_send, Result};
+
+/// Copies `len` bytes from `from` to `to`.
+///
+/// # Safety
+///
+/// - `to` must be writable for `len` bytes.
+/// - `src` must be readable for `len` bytes.
+/// - the ranges starting at `to` and `src` for `len` bytes must not overlap.
+/// - nothing mutates the memory of the `to` and `from` ranges while this function is called.
+pub unsafe fn test_memcpy(to: *mut u8, from: *const u8, len: u64) -> Result<()> {
+    let function = SalusTestFunction::MemCopy(MemCopyArgs {
+        to: to as u64,
+        from: from as u64,
+        len,
+    });
+    let msg = SalusSbiMessage::SalusTest(function).into();
+    ecall_send(&msg)?;
+    Ok(())
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -17,5 +17,8 @@ pub const EXT_TEE_HOST: u64 = 0x54454548; // TEEH
 pub const EXT_TEE_INTERRUPT: u64 = 0x54454549; // TEEI
 pub const EXT_TEE_GUEST: u64 = 0x54454547; // TEEG
 
+pub const EXT_VENDOR_RANGE_START: u64 = 0x09000000;
+pub const EXT_VENDOR_RANGE_END: u64 = 0x09FFFFFF;
+
 pub const SBI_SUCCESS: i64 = 0;
 pub const SBI_ERR_INVALID_ADDRESS: i64 = -5;

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,5 +47,5 @@ impl Error {
     }
 }
 
-/// Holds the result of a TEE operation.
+/// Holds the result of a SBI operation.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/salus.rs
+++ b/src/salus.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2023 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::*;
+use crate::{SbiFunction, SbiMessage};
+
+// Salus Vendor Extensions.
+
+const EXT_SALUS_TEST: u64 = 0x09FFFFFF;
+
+/// Salus-specific SBI vendor extensions.
+pub enum SalusSbiMessage {
+    /// Salus Test functions.
+    SalusTest(SalusTestFunction),
+}
+
+impl SalusSbiMessage {
+    /// Parse a Salus Sbi Message from registers.
+    pub fn from_regs(args: &[u64]) -> Result<Self> {
+        use SalusSbiMessage::*;
+        match args[7] {
+            EXT_SALUS_TEST => SalusTestFunction::from_regs(args).map(SalusTest),
+            _ => Err(Error::NotSupported),
+        }
+    }
+
+    /// Returns the `SbiFunction` trait of this message.
+    fn func(&self) -> impl SbiFunction {
+        use SalusSbiMessage::*;
+        match *self {
+            SalusTest(func) => func,
+        }
+    }
+
+    /// Returns the Extension ID of this message.
+    fn eid(&self) -> u64 {
+        use SalusSbiMessage::*;
+        match *self {
+            SalusTest(_) => EXT_SALUS_TEST,
+        }
+    }
+}
+
+impl From<SalusSbiMessage> for SbiMessage {
+    fn from(msg: SalusSbiMessage) -> SbiMessage {
+        let args: [u64; 8] = [
+            msg.func().a0(),
+            msg.func().a1(),
+            msg.func().a2(),
+            msg.func().a3(),
+            msg.func().a4(),
+            msg.func().a5(),
+            msg.func().a6(),
+            msg.eid(),
+        ];
+        SbiMessage::Vendor(args)
+    }
+}
+
+/// Functions defined for the Salus Test extension
+#[derive(Clone, Copy, Debug)]
+pub enum SalusTestFunction {
+    /// Memcopy Test.
+    MemCopy(MemCopyArgs),
+}
+
+impl SalusTestFunction {
+    /// Attempts to parse `Self` from the passed in `a0-a7`.
+    pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
+        use SalusTestFunction::*;
+
+        match args[6] {
+            0 => Ok(MemCopy(MemCopyArgs {
+                to: args[0],
+                from: args[1],
+                len: args[2],
+            })),
+            _ => Err(Error::NotSupported),
+        }
+    }
+}
+
+impl SbiFunction for SalusTestFunction {
+    fn a0(&self) -> u64 {
+        use SalusTestFunction::*;
+        match self {
+            MemCopy(args) => args.to,
+        }
+    }
+
+    fn a1(&self) -> u64 {
+        use SalusTestFunction::*;
+        match self {
+            MemCopy(args) => args.from,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        use SalusTestFunction::*;
+        match self {
+            MemCopy(args) => args.len,
+        }
+    }
+
+    fn a6(&self) -> u64 {
+        use SalusTestFunction::*;
+        match self {
+            MemCopy(_) => 0,
+        }
+    }
+}
+
+/// Arguments to the memcpy test function
+#[derive(Clone, Copy, Debug)]
+pub struct MemCopyArgs {
+    /// Destination Address.
+    pub to: u64,
+    /// Source Address.
+    pub from: u64,
+    /// Length in bytes of the copy.
+    pub len: u64,
+}

--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -43,6 +43,9 @@ pub use tee_guest::*;
 mod pmu;
 pub use pmu::*;
 
+/// Salus SBI Vendor Extensions.
+pub mod salus;
+
 /// Interfaces for invoking SBI functionality.
 pub mod api;
 

--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -130,6 +130,8 @@ pub enum SbiMessage {
     Attestation(AttestationFunction),
     /// The extension for getting performance counter state.
     Pmu(PmuFunction),
+    /// Vendor extensions.
+    Vendor([u64; 8]),
 }
 
 impl SbiMessage {
@@ -151,6 +153,9 @@ impl SbiMessage {
             EXT_TEE_GUEST => TeeGuestFunction::from_regs(args).map(SbiMessage::TeeGuest),
             EXT_ATTESTATION => AttestationFunction::from_regs(args).map(SbiMessage::Attestation),
             EXT_PMU => PmuFunction::from_regs(args).map(SbiMessage::Pmu),
+            EXT_VENDOR_RANGE_START..=EXT_VENDOR_RANGE_END => Ok(SbiMessage::Vendor(
+                args.try_into().map_err(|_| Error::Failed)?,
+            )),
             _ => Err(Error::NotSupported),
         }
     }
@@ -170,6 +175,7 @@ impl SbiMessage {
             TeeGuest(_) => EXT_TEE_GUEST,
             Attestation(_) => EXT_ATTESTATION,
             Pmu(_) => EXT_PMU,
+            Vendor(regs) => regs[7],
         }
     }
 
@@ -190,6 +196,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a6(),
             Attestation(f) => f.a6(),
             Pmu(f) => f.a6(),
+            Vendor(regs) => regs[6],
         }
     }
 
@@ -208,6 +215,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a5(),
             Attestation(f) => f.a5(),
             Pmu(f) => f.a5(),
+            Vendor(regs) => regs[5],
         }
     }
 
@@ -226,6 +234,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a4(),
             Attestation(f) => f.a4(),
             Pmu(f) => f.a4(),
+            Vendor(regs) => regs[4],
         }
     }
 
@@ -244,6 +253,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a3(),
             Attestation(f) => f.a3(),
             Pmu(f) => f.a3(),
+            Vendor(regs) => regs[3],
         }
     }
 
@@ -262,6 +272,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a2(),
             Attestation(f) => f.a2(),
             Pmu(f) => f.a2(),
+            Vendor(regs) => regs[2],
         }
     }
 
@@ -280,6 +291,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a1(),
             Attestation(f) => f.a1(),
             Pmu(f) => f.a1(),
+            Vendor(regs) => regs[1],
         }
     }
 
@@ -298,6 +310,7 @@ impl SbiMessage {
             TeeGuest(f) => f.a0(),
             Attestation(f) => f.a0(),
             Pmu(f) => f.a0(),
+            Vendor(regs) => regs[0],
         }
     }
 

--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -340,7 +340,7 @@ impl SbiMessage {
     }
 }
 
-/// Send an ecall to the firmware or hypervisor.
+/// Sends an ecall to the firmware or hypervisor.
 ///
 /// # Safety
 ///

--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -366,6 +366,11 @@ pub unsafe fn ecall_send(msg: &SbiMessage) -> Result<u64> {
 }
 
 #[cfg(not(all(target_arch = "riscv64", target_os = "none")))]
-unsafe fn ecall_send(_msg: &SbiMessage) -> Result<u64> {
+/// Test Compilation only.
+///
+/// # Safety
+///
+/// Test-only. Do not call.
+pub unsafe fn ecall_send(_msg: &SbiMessage) -> Result<u64> {
     panic!("ecall_send called");
 }


### PR DESCRIPTION
This patch allows SBI users to create vendor extensions to wrap the standard SBI implementation.

An `enum` `T` implementing trait `VendorExtension` will be able to be be used in `VendorSbiMessage<T>`, and be parsed as SBI messages in code using this library.

As an example, this [change] would allow `salus` to use `SalusSbiMessage` (alias for `VendorSbiMessage<SalusExtension`) to parse salus-specific vendor extensions.

This is a RFC.  

[change]: https://github.com/glg-rv/salus/commit/34d42d908520c6be556bd8127ae1eb737d8f60c3