### PR TITLE
Add [repr(C)] to Shared Nacl structure.

### DIFF
--- a/src/nacl.rs
+++ b/src/nacl.rs
@@ -9,6 +9,7 @@ use crate::function::*;
 pub const NACL_SCRATCH_BYTES: usize = 2048;
 
 /// Layout of the shared-memory area registered with `SetShmem`.
+#[repr(C)]
 pub struct NaclShmem {
     /// Scratch space. The layout of this scratch space is defined by the particular function being
     /// invoked.


### PR DESCRIPTION
Given Nacl struct is shared with the host, adding [repr(C)] to make sure the fields are not reordered.

Signed-off-by: Rajnesh Kanwal <rkanwal@rivosinc.com>