### PR TITLE
Expose error module to out of tree users

### DIFF
--- a/src/sbi.rs
+++ b/src/sbi.rs
@@ -11,7 +11,8 @@ mod consts;
 pub use consts::*;
 mod debug_console;
 pub use debug_console::*;
-mod error;
+/// Error types encapsulating SBI error codes
+pub mod error;
 pub use error::*;
 mod function;
 pub use function::*;


### PR DESCRIPTION
While attempting to add a new extension without separating it from it's host project, I noticed I could not use any of the standard sbi-rs error types.

This is a fairly quick and dirty fix, but it does allow me to build extensions outside of SBI-RS (while still using sbi-rs).