### PR TITLE
Nacl: Add support to probe Nacl features.

### DIFF
--- a/src/api/nacl.rs
+++ b/src/api/nacl.rs
@@ -6,8 +6,6 @@ use crate::NaclFunction::*;
 use crate::NaclShmem;
 use crate::{ecall_send, Result, SbiMessage};
 
-const PFN_SHIFT: u64 = 12;
-
 /// Registers the nested hypervisor <-> host hypervisor shared memory area for the calling CPU.
 /// `shmem_ptr` must be page-aligned and refer to a sufficient number of accessible, contiguous
 /// pages to hold a `NaclShmem` struct. The pages must remain accessible until the shared-memory area
@@ -21,7 +19,7 @@ const PFN_SHIFT: u64 = 12;
 /// until it is unregistered.
 pub unsafe fn register_shmem(shmem_ptr: *mut NaclShmem) -> Result<()> {
     let msg = SbiMessage::Nacl(SetShmem {
-        shmem_pfn: (shmem_ptr as u64) >> PFN_SHIFT,
+        shmem_addr: shmem_ptr as u64,
     });
     ecall_send(&msg)?;
     Ok(())
@@ -30,7 +28,7 @@ pub unsafe fn register_shmem(shmem_ptr: *mut NaclShmem) -> Result<()> {
 /// Unregisters the nested hypervisor <-> host hypervisor  shared memory area for the calling CPU.
 pub fn unregister_shmem() -> Result<()> {
     let msg = SbiMessage::Nacl(SetShmem {
-        shmem_pfn: u64::MAX,
+        shmem_addr: u64::MAX,
     });
     // Safety: Doesn't access host memory.
     unsafe { ecall_send(&msg) }?;


### PR DESCRIPTION
In the recent updates to Nacl extension [0], feature probing was introduced and allows guest hypervisor to probe which features are supported by the host hypervisor.

Also, the SetShmem FID argument has changed from pfn to full address of the shared memory page.

[0] https://lists.riscv.org/g/sig-hypervisors/message/256