### PR TITLE
sbi, api: Use i64 in SbiReturn type

### DIFF
--- a/src/api/attestation.rs
+++ b/src/api/attestation.rs
@@ -62,14 +62,14 @@ pub fn get_evidence(
     // passed as arguments.
     // GetEvidence writes to a single reference to `cert_bytes``, which is
     // defined in this scope.
-    let len = unsafe { ecall_send(&msg) }?;
+    let len: usize = unsafe { ecall_send(&msg) }?;
 
     // Safety: cert_bytes is backed by a MAX_CERT_SIZE array.
     unsafe {
-        if len as usize > MAX_CERT_SIZE {
+        if len > MAX_CERT_SIZE {
             return Err(Error::Failed);
         }
-        cert_bytes.set_len(len as usize);
+        cert_bytes.set_len(len);
     };
 
     Ok(cert_bytes)
@@ -110,14 +110,14 @@ pub fn read_measurement(index: usize) -> Result<ArrayVec<u8, MAX_HASH_SIZE>> {
 
     // Safety: ReadMeasurement writes into a single reference to `msmt_bytes`,
     // which is defined in this scope.
-    let len = unsafe { ecall_send(&msg) }?;
+    let len: usize = unsafe { ecall_send(&msg) }?;
 
     // Safety: msmt_bytes is backed by a MAX_HASH_SIZE array.
     unsafe {
-        if len as usize > MAX_HASH_SIZE {
+        if len > MAX_HASH_SIZE {
             return Err(Error::Failed);
         }
-        msmt_bytes.set_len(len as usize);
+        msmt_bytes.set_len(len);
     };
 
     Ok(msmt_bytes)

--- a/src/api/cove_host.rs
+++ b/src/api/cove_host.rs
@@ -110,7 +110,7 @@ pub fn get_info() -> Result<TsmInfo> {
         len: tsm_info_size,
     });
     // Safety: The passed info pointer is uniquely owned so it's safe to modify in SBI.
-    let tsm_info_len = unsafe { ecall_send(&msg)? };
+    let tsm_info_len: u64 = unsafe { ecall_send(&msg)? };
 
     if tsm_info_len != tsm_info_size {
         return Err(Error::Failed);


### PR DESCRIPTION
This moves the type to correctly match the specification. Through the
use of the From trait on SbiReturn it is possible to get access to the
result of the call as the desired type.

In all cases the value is interpretted as the raw bit value with no
runtime checking (e.g. no checking that a u64 fits into the i64.)

The individual users of the the ecall_send() API can choose the type
that they desire and interpret as required.

See: https://github.com/rivosinc/salus/issues/38

Signed-off-by: Rob Bradford <rbradford@rivosinc.com>
