### PR TITLE
debug_console: Update to match ratified version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 name = "sbi_rs"
 authors = ["Rivos, Inc."]
 license = "Apache-2.0"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/src/api/debug_console.rs
+++ b/src/api/debug_console.rs
@@ -6,9 +6,10 @@ use crate::{ecall_send, DebugConsoleFunction, Result, SbiMessage};
 
 /// Prints the given string in a platfrom-dependent way.
 pub fn console_puts(chars: &[u8]) -> Result<()> {
-    let msg = SbiMessage::DebugConsole(DebugConsoleFunction::PutString {
+    let msg = SbiMessage::DebugConsole(DebugConsoleFunction::Write {
         len: chars.len() as u64,
         addr: chars.as_ptr() as u64,
+        addr_hi: 0,
     });
 
     // Safety: The sbi implementation is trusted not to write memory when printing to the console.

--- a/src/debug_console.rs
+++ b/src/debug_console.rs
@@ -9,11 +9,27 @@ use crate::function::*;
 #[derive(Copy, Clone, Debug)]
 pub enum DebugConsoleFunction {
     /// Prints the given string to the system console.
-    PutString {
+    Write {
         /// The length of the string to print.
         len: u64,
         /// The address of the string.
         addr: u64,
+        /// For rv32, the upper bits of address if needed.
+        addr_hi: u64,
+    },
+    /// Reads from the console.
+    Read {
+        /// The length of the buffer to read into.
+        len: u64,
+        /// The address of the buffer to read into.
+        addr: u64,
+        /// For rv32, the upper bits of address if needed.
+        addr_hi: u64,
+    },
+    /// Writes a single byte to the console.
+    WriteByte {
+        /// The byte to write.
+        byte: u64,
     },
 }
 
@@ -21,10 +37,17 @@ impl DebugConsoleFunction {
     /// Attempts to parse `Self` from the passed in `a0-a7`.
     pub(crate) fn from_regs(args: &[u64]) -> Result<Self> {
         Ok(match args[6] {
-            0 => DebugConsoleFunction::PutString {
+            0 => DebugConsoleFunction::Write {
                 len: args[0],
                 addr: args[1],
+                addr_hi: args[2],
             },
+            1 => DebugConsoleFunction::Read {
+                len: args[0],
+                addr: args[1],
+                addr_hi: args[2],
+            },
+            2 => DebugConsoleFunction::WriteByte { byte: args[0] },
             _ => return Err(Error::NotSupported),
         })
     }
@@ -33,13 +56,49 @@ impl DebugConsoleFunction {
 impl SbiFunction for DebugConsoleFunction {
     fn a0(&self) -> u64 {
         match self {
-            DebugConsoleFunction::PutString { len, addr: _ } => *len,
+            DebugConsoleFunction::Write {
+                len,
+                addr: _,
+                addr_hi: _,
+            } => *len,
+            DebugConsoleFunction::Read {
+                len,
+                addr: _,
+                addr_hi: _,
+            } => *len,
+            DebugConsoleFunction::WriteByte { byte } => *byte,
         }
     }
 
     fn a1(&self) -> u64 {
         match self {
-            DebugConsoleFunction::PutString { len: _, addr } => *addr,
+            DebugConsoleFunction::Write {
+                len: _,
+                addr,
+                addr_hi: _,
+            } => *addr,
+            DebugConsoleFunction::Read {
+                len: _,
+                addr,
+                addr_hi: _,
+            } => *addr,
+            DebugConsoleFunction::WriteByte { byte: _ } => 0,
+        }
+    }
+
+    fn a2(&self) -> u64 {
+        match self {
+            DebugConsoleFunction::Write {
+                len: _,
+                addr: _,
+                addr_hi,
+            } => *addr_hi,
+            DebugConsoleFunction::Read {
+                len: _,
+                addr: _,
+                addr_hi,
+            } => *addr_hi,
+            DebugConsoleFunction::WriteByte { byte: _ } => 0,
         }
     }
 }


### PR DESCRIPTION
The ratified version of the debug console supports a read and single byte write. Additionally, the PutString function was named "Write".

Bump the version string as this is a breaking change.